### PR TITLE
More catgirl stuff

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -204,6 +204,8 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 
 #define isstructure(A) (istype(A, /obj/structure))
 
+#define istree(A) (istype(A, /obj/structure/flora/tree))
+
 #define ismachinery(A) (istype(A, /obj/machinery))
 
 #define ismecha(A) (istype(A, /obj/mecha))

--- a/code/datums/components/melee_special.dm
+++ b/code/datums/components/melee_special.dm
@@ -5,8 +5,9 @@
 #define WS_TARGET_IGNORE_SELF (1<<2) // target self
 #define WS_TARGET_MOBS (1<<3) // hit all mobs on the turf
 #define WS_TARGET_STRUCTURES (1<<4) // hit objects on the turf
-#define WS_TARGET_MACHINES (1<<5) // hit machines on the turf
-#define WS_TARGET_WALLS (1<<6) // hit opaque walls on the turf
+#define WS_TARGET_TREES (1<<5) // hit trees on the turf
+#define WS_TARGET_MACHINES (1<<6) // hit machines on the turf
+#define WS_TARGET_WALLS (1<<7) // hit opaque walls on the turf
 //#define WS_TARGET_PREFERED_FIRST (1<<6) // If we hit multiple objects, hit the prefered one first
 #define WS_TARGET_ALL (1<<8) // Hit all objects on the turf -- probably dont use this
 
@@ -36,7 +37,7 @@
 	/// List of which intents trigger this thing
 	var/list/intent_flags = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)
 	/// targetting flags
-	var/target_flags = WS_TARGET_WALLS | WS_TARGET_IGNORE_DEAD | WS_TARGET_IGNORE_SELF | WS_TARGET_MOBS | WS_TARGET_STRUCTURES | WS_TARGET_MACHINES
+	var/target_flags = WS_TARGET_WALLS | WS_TARGET_IGNORE_DEAD | WS_TARGET_IGNORE_SELF | WS_TARGET_MOBS | WS_TARGET_MACHINES | WS_TARGET_TREES
 	/// target mode
 	var/target_mode = WS_FURTHEST_POPULATED_TILE
 	/// damage flags
@@ -74,7 +75,7 @@
 	line_effect = TRUE
 	effect_kind = null
 	target_mode = WS_ALL_POPULATED_TILES
-	target_flags = WS_TARGET_WALLS | WS_TARGET_IGNORE_DEAD | WS_TARGET_IGNORE_SELF | WS_TARGET_MOBS | WS_TARGET_STRUCTURES | WS_TARGET_MACHINES | WS_TARGET_WALLS
+	target_flags = WS_TARGET_WALLS | WS_TARGET_IGNORE_DEAD | WS_TARGET_IGNORE_SELF | WS_TARGET_MOBS | WS_TARGET_MACHINES | WS_TARGET_TREES
 	damage_flags = WS_DAMAGE_FALLOFF_FAR_HIGH
 
 /datum/component/weapon_special/ranged_spear/longer/pike
@@ -92,7 +93,7 @@
 	line_effect = ATTACK_EFFECT_PUNCH
 	effect_kind = null
 	target_mode = WS_ALL_POPULATED_TILES
-	target_flags = WS_TARGET_WALLS | WS_TARGET_IGNORE_DEAD | WS_TARGET_IGNORE_SELF | WS_TARGET_MOBS | WS_TARGET_STRUCTURES | WS_TARGET_MACHINES | WS_TARGET_WALLS
+	target_flags = WS_TARGET_WALLS | WS_TARGET_IGNORE_DEAD | WS_TARGET_IGNORE_SELF | WS_TARGET_MOBS | WS_TARGET_MACHINES | WS_TARGET_TREES
 	damage_flags = NONE
 
 /datum/component/weapon_special/Initialize()
@@ -325,6 +326,9 @@
 			. |= atomhere
 			continue
 		//var/isprefd = is_type_in_list(atomhere, prefered_types)
+		if(CHECK_BITFIELD(target_flags, WS_TARGET_TREES) && istree(atomhere))
+			. |= atomhere
+			continue
 		if((CHECK_BITFIELD(target_flags, WS_TARGET_STRUCTURES) && isstructure(atomhere)))
 			. |= atomhere
 			continue

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -252,21 +252,25 @@
 	if (!on || !anchored || (stat & BROKEN) || !powered())
 		//end_processing()
 		STOP_PROCESSING(SSfastprocess, src)
-		STOP_PROCESSING(SSmachines, src)
+		// STOP_PROCESSING(SSmachines, src)
 		processing_state = TURRET_PROCESS_OFF
 		return FALSE
-	//START_PROCESSING(SSmachines, src)
-	//begin_processing()
-	if(activity_state == TURRET_SLEEP_MODE)
-		STOP_PROCESSING(SSfastprocess, src)
-		START_PROCESSING(SSmachines, src)
-		processing_state = TURRET_PROCESS_MACHINE
-		return TRUE
 	else
-		STOP_PROCESSING(SSmachines, src)
 		START_PROCESSING(SSfastprocess, src)
 		processing_state = TURRET_PROCESS_FAST
 		return TRUE
+	//START_PROCESSING(SSmachines, src)
+	//begin_processing()
+	// if(activity_state == TURRET_SLEEP_MODE)
+	// 	STOP_PROCESSING(SSfastprocess, src)
+	// 	START_PROCESSING(SSmachines, src)
+	// 	processing_state = TURRET_PROCESS_MACHINE
+	// 	return TRUE
+	// else
+	// 	STOP_PROCESSING(SSmachines, src)
+	// 	START_PROCESSING(SSfastprocess, src)
+	// 	processing_state = TURRET_PROCESS_FAST
+	// 	return TRUE
 
 /obj/machinery/porta_turret/update_icon_state()
 	if(!anchored)
@@ -570,6 +574,10 @@
 
 	if(!check_should_process())
 		return
+	if(last_target)
+		var/atom/target = GET_WEAKREF(last_target)
+		if(HAS_TRAIT(target, "stealthinvis"))
+			interrupt_and_set_to_evasion()
 	/// We dont have a target, look for targets. If we just got out of shooting, beep while scanning for a while
 	if(activity_state == TURRET_SLEEP_MODE || activity_state == TURRET_EVASION_MODE)
 		if(scan_for_targets())
@@ -2149,7 +2157,10 @@
 /obj/machinery/porta_turret/f13/nash/proc/undeploy_turret(obj/item/m_tool, mob/user)
 	visible_message(span_notice("[user] starts packing up [src]!"),
 		span_notice("You starts packing up [src]!"))
-	if(!m_tool.use_tool(src, user, 3 SECONDS, 0, 100))
+	start_being_multitooled(m_tool, user)
+	var/succ = m_tool.use_tool(src, user, 3 SECONDS, 0, 100)
+	stop_being_multitooled(m_tool, user)
+	if(!succ)
 		user.show_message(span_alert("You were interrupted"))
 		return
 	visible_message(span_notice("[user] packed up [src]!"),
@@ -2161,6 +2172,10 @@
 	our_mag.forceMove(the_box)
 	our_mag = null
 	qdel(src)
+
+/obj/machinery/porta_turret/f13/nash/proc/start_being_multitooled(obj/item/m_tool, mob/user)
+
+/obj/machinery/porta_turret/f13/nash/proc/stop_being_multitooled(obj/item/m_tool, mob/user)
 
 /obj/machinery/porta_turret/f13/nash/proc/sorta_heal_turret(mob/user)
 	if(obj_integrity >= initial(obj_integrity))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -434,7 +434,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 
 /obj/item/attackby(obj/item/W, mob/user, params)
 	. = ..()
-	if(berryable)
+	if(berryable && check_faction(user))
 		tryberry(W, user)
 
 /obj/item/on_attack_hand(mob/user, act_intent = user.a_intent, unarmed_attack_flags)

--- a/code/game/objects/items/fish.dm
+++ b/code/game/objects/items/fish.dm
@@ -4,6 +4,13 @@
 	desc = "debug, report to Jake"
 	icon = 'icons/obj/fish/fish_items.dmi'
 	w_class = WEIGHT_CLASS_SMALL
+	attack_verb = list("slapped", "plopped", "squortched", "smarped", "splooshed", "blorped")
+	force = 5 //needs to multiply to 150
+	backstab_multiplier = 2
+	factionbound = list(CGP_FACTION_CATGIRL)
+	berryable = TRUE
+	hitsound = 'sound/effects/hit_punch.ogg'
+	weapon_special_component = /datum/component/weapon_special/single_turf
 	//the type of meat it drops
 	var/meat_type
 	//the max primary meat it drops
@@ -16,6 +23,7 @@
 	var/max_secondary = 3
 	//sex that is contributing to allowing breeding
 	var/spawn_sex = FEMALE
+	var/catgirl_stealth_fish = FALSE
 
 //made a proc so that it can be influenced by other stuff
 /obj/item/fishy/proc/randomize_sex()
@@ -44,6 +52,26 @@
 	else
 		return ..()
 
+/obj/item/fishy/pickup(mob/user)
+	if(catgirl_stealth_fish)
+		if(check_faction(user))
+			force = 50
+			backstab_multiplier = 5
+		else
+			force = initial(force)
+			backstab_multiplier = initial(backstab_multiplier)
+	return ..()
+
+/obj/item/fishy/examine(mob/user)
+	. = ..()
+	if(catgirl_stealth_fish && check_faction(user))
+		. += span_notice("Nya! You are a master(ess) of fishfighting, you sly cat!")
+		. += span_notice("You can hit people really hard with this fish, and from behind, you'll surely knock them out!")
+		. += span_notice("Its also a tasty snack if you have the means to butcher it! Course then you wont have the fish anymore...")
+	else
+		. += span_notice("While demoralizing to your opponents, this fish makes for a poor weapon. If only you had the feline wiles to use it to its full potential...")
+		. += span_notice("It is, however, a tasty snack if you have the means to butcher it! Course then you wont have the fish anymore...")
+
 //ive taken it into my hands to have all the fish have puns, send help - jake
 //also, please make more actual fish meat and food with the new fish meat, please
 //and secondary_drops will not be fishyeggs once actual fish tanks are implemented
@@ -53,6 +81,15 @@
 	icon_state = "carp"
 	meat_type = /obj/item/reagent_containers/food/snacks/fishmeat/carp
 	secondary_drop = /obj/item/fishyegg/carp
+
+/obj/item/fishy/carp/catgirl_backstabber
+	name = "nekarp"
+	desc = "A big thiccass fish, commonly found in the Whiskermitten Rivers. \
+	Locals speak hushed whispers of its use in the horny art of felicopiscis, \
+	'catfishing', which somehow involves using this unwieldy chonker of a fish \
+	to beat the everliving heck out of people they find attractive. To everyone \
+	else, it's a slipperyass fish that hits like a flyswatter."
+	catgirl_stealth_fish = TRUE
 
 /obj/item/fishy/salmon
 	name = "salmon"

--- a/code/game/objects/items/stealthboy.dm
+++ b/code/game/objects/items/stealthboy.dm
@@ -16,10 +16,11 @@
 	var/can_play_low_power_warning_boop = TRUE
 	var/on = FALSE
 	var/warn_time = 1 SECONDS
-	var/max_time_left = 20 SECONDS
-	var/time_left = 20 SECONDS
+	var/max_time_left = 30 SECONDS
+	var/time_left = 30 SECONDS
 	var/min_time_left = 15 SECONDS
 	var/last_tick = 0
+	var/charge_time_multiplier = 1.0
 	var/list/factionlist = list(
 		"supermutant",
 		"raider",
@@ -241,7 +242,7 @@
 	if(!check_faction(loc))
 		if(prob(80))
 			return // lol
-	time_left += (delta * 0.75)
+	time_left += (delta * charge_time_multiplier)
 	if(can_play_charged_enough_boop && time_left > min_time_left)
 		var/mob/user = loc
 		if(ismob(user))

--- a/code/modules/WVM/wvm_vendors.dm
+++ b/code/modules/WVM/wvm_vendors.dm
@@ -78,6 +78,7 @@
 		new /datum/data/wasteland_equipment("Dart Musket",          /obj/item/gun/flintlock/musket/catgirl,                            	50),
 		new /datum/data/wasteland_equipment("Dart Box",             /obj/item/ammo_box/foambox/catbox,                               	20),
 		new /datum/data/wasteland_equipment("Pet Collar",           /obj/item/clothing/neck/petcollar/choker,							30),
+		new /datum/data/wasteland_equipment("Multitool (against turrets!)",           /obj/item/multitool,							5),
 		
 		)
 
@@ -122,6 +123,7 @@
 		new /datum/data/wasteland_equipment("Shield",			/obj/item/shield/coyote/kiteshield,							50),
 		new /datum/data/wasteland_equipment("Darts",			/obj/item/ammo_box/foambox/catbox,							20),
 		new /datum/data/wasteland_equipment("Pet Collar",           /obj/item/clothing/neck/petcollar/choker,				30),
+		new /datum/data/wasteland_equipment("Multitool",           /obj/item/multitool,							5),
 		)
 
 

--- a/code/modules/jobs/job_types/catlonial_murrine_jobs.dm
+++ b/code/modules/jobs/job_types/catlonial_murrine_jobs.dm
@@ -420,6 +420,13 @@
 	shot_speed_mod = 0.35
 	burst_count = 1
 	var/cat = FALSE
+	var/being_multitooled = FALSE
+	var/cat_next_spark = 0
+	var/cat_spark_interval_min = 3 SECONDS
+	var/cat_spark_interval_max = 7 SECONDS
+	var/sap_next_spark = 0
+	var/sap_spark_interval_min = 0.5 SECONDS
+	var/sap_spark_interval_max = 1.5 SECONDS
 
 /obj/machinery/porta_turret/f13/nash/foam/apply_faction_stuff()
 	. = ..()
@@ -430,9 +437,28 @@
 
 /obj/machinery/porta_turret/f13/nash/foam/process()
 	if(cat)
-		if(prob(10))
+		if(world.time >= cat_next_spark)
+			cat_next_spark = world.time + rand(cat_spark_interval_min, cat_spark_interval_max)
 			do_sparks(rand(1, 2), TRUE, get_turf(src))
+	if(being_multitooled)
+		if(world.time >= sap_next_spark)
+			sap_next_spark = world.time + rand(sap_spark_interval_min, sap_spark_interval_max)
+			do_sparks(rand(1, 3), TRUE, get_turf(src))
 	. = ..()
+
+/obj/machinery/porta_turret/f13/nash/foam/dont_scan()
+	. = ..()
+	if(.)
+		return .
+	if(being_multitooled) // catgirl sappin my sentry!
+		return TRUE
+
+/obj/machinery/porta_turret/f13/nash/foam/start_being_multitooled(mob/user)
+	change_activity_state(TURRET_SLEEP_MODE)
+	being_multitooled = TRUE
+
+/obj/machinery/porta_turret/f13/nash/foam/stop_being_multitooled(mob/user)
+	being_multitooled = FALSE
 
 /obj/machinery/porta_turret/f13/nash/foam/obj_break(damage_flag)
 	if(!(flags_1 & NODECONSTRUCT_1))

--- a/code/modules/jobs/job_types/outfits_we_use.dm
+++ b/code/modules/jobs/job_types/outfits_we_use.dm
@@ -117,7 +117,7 @@
 	name = "Nyanfiltrator"
 	head = null
 	suit = null
-	backpack = null
+	backpack = /obj/item/storage/backpack/trekker
 	uniform = /obj/item/clothing/under/civ/mayan_loincloth
 	shoes = /obj/item/clothing/shoes/sandal
 	belt = /obj/item/stealthboy
@@ -126,6 +126,10 @@
 	r_pocket = /obj/item/melee/unarmed/brass/knyackles
 	tribal = TRUE
 	cat = TRUE
+	backpack_contents   = list(
+	/obj/item/multitool = 1,
+	/obj/item/fishy/carp/catgirl_backstabber = 1,
+	)
 
 /datum/outfit/job/cb/catgirl/warrior/catnapper
 	name = "Catnapper"

--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -312,6 +312,9 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 /obj/structure/stone_tile/singularity_pull()
 	return
 
+/obj/structure/stone_tile/attackby(obj/item/I, mob/living/user, params, damage_override)
+	return STOP_ATTACK_PROC_CHAIN
+
 /obj/structure/stone_tile/proc/on_entered(atom/movable/AM)
 	SIGNAL_HANDLER
 	if(falling || fallen)


### PR DESCRIPTION
Multitooling a turret will immediately cause it to de-aggro while its being multitooled

Turrets more aggressively stop targetting people who become invisible

Turrets spark a lot more when they're multitooled or setup by catgirls

You can hit people with fish

Nyanfiltrator gets a fish that acts like her brass nyackles, but basically harmless in non-catgirl hands

Stealthboy lasts a bit longer and recharges a bit faster

Those melee whiff attack things should no longer smash into the catgirl camp tiles. FENNY PLEASE CHANGE THEM TO SOMETHING OTHER THAN THE NECROPOLIS BOSS ARENA FLOOR TILES

Catgirl camp tiles are no longer meleeable, they were unbreakable anyway so this just means less hitting the floor with your dumb cat things

Only catgirls can berry things

oh yeah the thing fenny asked me to do for this pr. added multitools to the vendors, and the nyanfiltrator loadout. also the nyanfiltrator starts with a backpack now